### PR TITLE
Rename project from anastrophex to prefrontalos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Anastrophex** is an MCP (Model Context Protocol) server that helps AI assistants recognize and break out of failure patterns by:
+**PrefrontalOS** is an MCP (Model Context Protocol) server that helps AI assistants recognize and break out of failure patterns by:
 1. Detecting loops in tool calls and command patterns
 2. Injecting timely directives from CLAUDE.md/AI_CREDO.md
 3. Learning what works via mnemex integration
@@ -43,10 +43,10 @@ uv run mypy src/
 ### Running the Server
 ```bash
 # Run as installed command
-anastrophex
+prefrontalos
 
 # Or run as module
-python -m anastrophex.server
+python -m prefrontalos.server
 
 # Development installation
 uv pip install -e ".[dev]"
@@ -81,11 +81,11 @@ uv pip install -e ".[dev]"
 
 ### Key Components
 
-**Pattern Detector** (src/anastrophex/server.py:15-21)
+**Pattern Detector** (src/prefrontalos/server.py:15-21)
 - Monitors tool_history for repetitive patterns
 - Currently stub implementation - stores history but doesn't analyze
 
-**MCP Resources** (exposed via anastrophex://)
+**MCP Resources** (exposed via prefrontalos://)
 - `patterns/all` - All known behavior patterns
 - `alerts/active` - Currently triggered patterns
 - `directives/all` - Directives from CLAUDE.md
@@ -97,7 +97,7 @@ uv pip install -e ".[dev]"
 ### Directory Structure
 
 ```
-src/anastrophex/
+src/prefrontalos/
   __init__.py       - Package initialization
   server.py         - Main MCP server implementation
 tests/
@@ -110,7 +110,7 @@ docs/
   prompt-compression-strategy.md - Token optimization approach
 examples/
   crewai-test-case-study.md      - Oct 2025 CI/CD debugging case
-  anastrophex-venv-debugging.md  - venv environment debugging case
+  prefrontalos-venv-debugging.md  - venv environment debugging case
 ```
 
 ## Implementation Roadmap

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,661 @@
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Anastrophex
+# PrefrontalOS
 
 > **Anastrophe** (ἀναστροφή) = conduct, behavior in ancient Greek
 > Following the mnemex naming convention: memory + codex → conduct + codex
@@ -81,17 +81,17 @@ cd behavior-mcp
 uv pip install -e ".[dev]"
 
 # Run the server
-anastrophex
+prefrontalos
 
 # Or using Python module
-python -m anastrophex.server
+python -m prefrontalos.server
 ```
 
 ## Development
 
 **Status:** Planning/Design Phase
-**Package name:** `anastrophex`
-**Entry point:** `anastrophex` command
+**Package name:** `prefrontalos`
+**Entry point:** `prefrontalos` command
 
 See [ROADMAP.md](ROADMAP.md) for detailed implementation plan.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,4 @@
-# Anastrophex Implementation Roadmap
+# PrefrontalOS Implementation Roadmap
 
 ## Phase 1: Pattern Detection (Weeks 1-2)
 
@@ -31,7 +31,7 @@
 - [ ] Implement `DirectiveInjector` class
 - [ ] Design reminder format (⚠️ Loop detected template)
 - [ ] Inject reminders via tool result augmentation
-- [ ] Add MCP resource: `anastrophex://alerts/active`
+- [ ] Add MCP resource: `prefrontalos://alerts/active`
 - [ ] Test timing: trigger after N-1 attempts, before Nth
 
 ### Success Criteria

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,4 @@
-# Anastrophex Development TODO
+# PrefrontalOS Development TODO
 
 SMART Tasks: Specific, Measurable, Achievable, Relevant, Time-bound
 
@@ -323,15 +323,15 @@ SMART Tasks: Specific, Measurable, Achievable, Relevant, Time-bound
 **Objective:** Implement basic MCP server with core protocol support.
 
 **Acceptance Criteria:**
-- [ ] Update `src/anastrophex/server.py`
+- [ ] Update `src/prefrontalos/server.py`
 - [ ] Implement MCP protocol handlers:
   - `list_resources()` - available CREDO sections
   - `read_resource()` - load specific section
   - `list_tools()` - pattern detection tools
   - `call_tool()` - run pattern detection
 - [ ] Resource URIs:
-  - `anastrophex://credo/verify-before-acting`
-  - `anastrophex://credo/loop-detection`
+  - `prefrontalos://credo/verify-before-acting`
+  - `prefrontalos://credo/loop-detection`
   - etc.
 - [ ] Tool: `detect_pattern(context: dict) -> Violation`
 - [ ] Unit tests for all handlers
@@ -396,12 +396,12 @@ SMART Tasks: Specific, Measurable, Achievable, Relevant, Time-bound
 **Owner:** TBD
 **Due:** Day 7
 
-**Objective:** Allow users to configure anastrophex behavior.
+**Objective:** Allow users to configure prefrontalos behavior.
 
 **Acceptance Criteria:**
 - [ ] Create `config.yaml` with settings:
   ```yaml
-  anastrophex:
+  prefrontalos:
     timing:
       min_pause_seconds: 10
       max_pause_seconds: 30
@@ -438,7 +438,7 @@ SMART Tasks: Specific, Measurable, Achievable, Relevant, Time-bound
 **Acceptance Criteria:**
 - [ ] Extract test cases from:
   - `examples/crewai-test-case-study.md`
-  - `examples/anastrophex-venv-debugging.md`
+  - `examples/prefrontalos-venv-debugging.md`
   - GitHub API error session (documented today)
 - [ ] Create fixture: Simulated tool call history
 - [ ] Test scenarios:
@@ -511,7 +511,7 @@ SMART Tasks: Specific, Measurable, Achievable, Relevant, Time-bound
 
 **Acceptance Criteria:**
 - [ ] Update `README.md` with:
-  - What anastrophex does
+  - What prefrontalos does
   - How to install
   - How to configure
   - Example usage
@@ -598,7 +598,7 @@ SMART Tasks: Specific, Measurable, Achievable, Relevant, Time-bound
 - [ ] Document integration in `docs/integration-notes.md`
 - [ ] Example workflow:
   - Clear-Thought: Suggests "binary search" strategy
-  - Anastrophex: Enforces verbosity, detects loops
+  - PrefrontalOS: Enforces verbosity, detects loops
   - Mnemex: Records what worked
 - [ ] Test combined usage
 - [ ] Consider PR to clear-thought with tactical additions
@@ -670,7 +670,7 @@ SMART Tasks: Specific, Measurable, Achievable, Relevant, Time-bound
 **Owner:** All users
 
 **Activities:**
-- Record debugging sessions where anastrophex helped
+- Record debugging sessions where prefrontalos helped
 - Document false positives (refine detection)
 - Share intervention effectiveness
 - Build pattern library

--- a/docs/5w1h-framework.md
+++ b/docs/5w1h-framework.md
@@ -227,7 +227,7 @@ brew list package
 - ✗ Using wrong Python/Node/etc. (pyenv vs mise vs system)
 - ✗ Problem is specific to this repo's configuration
 
-### Real Example: Anastrophex venv
+### Real Example: PrefrontalOS venv
 
 ```bash
 # WHERE is Python?
@@ -504,7 +504,7 @@ Why? → Directive not surfaced at the right time
 
 Root Cause: No intervention when loop starts
 Actionable: Detect 2+ manual edits to .py after Black CI failure
-Prevention: Anastrophex pattern detection + intervention
+Prevention: PrefrontalOS pattern detection + intervention
 ```
 
 ### Real Example 3: Mypy 77 Errors
@@ -617,7 +617,7 @@ When stuck on a problem:
 **Mental Model:** [What rule to remember]
 ```
 
-### Anastrophex Integration
+### PrefrontalOS Integration
 
 **When to trigger 5 Whys:**
 ```python
@@ -843,7 +843,7 @@ ls -lO .venv/lib/.../site-packages/
 # → New pattern to record
 ```
 
-### Integration with Anastrophex
+### Integration with PrefrontalOS
 
 **Pattern Detection:**
 - Monitor for WHO issues (permission errors)
@@ -885,7 +885,7 @@ pattern:
 
 ---
 
-## Next Steps for Anastrophex
+## Next Steps for PrefrontalOS
 
 1. **Implement WHO detection** (permission errors)
 2. **Implement WHAT enforcement** (verbosity escalation)

--- a/docs/ai-credo-integration.md
+++ b/docs/ai-credo-integration.md
@@ -1,6 +1,6 @@
-# AI_CREDO Integration with Anastrophex
+# AI_CREDO Integration with PrefrontalOS
 
-How anastrophex detects violations of AI_CREDO principles and provides interventions.
+How prefrontalos detects violations of AI_CREDO principles and provides interventions.
 
 ## Core Principle 0: When Errors Occur, SLOW DOWN & THINK
 
@@ -93,7 +93,7 @@ Debugging requires sequential, deliberate execution.
 
 ### Pattern Examples from Our Sessions
 
-**Anastrophex venv debugging:**
+**PrefrontalOS venv debugging:**
 - ❌ Error at 17:23:15, next command at 17:23:18 (3 seconds)
 - ❌ Another command at 17:23:22 (4 seconds later)
 - ❌ User intervention: "you just hit two big errors and aren't trying to diagnose"
@@ -314,7 +314,7 @@ Example:
 
 **AI_CREDO Rule:** "Read, write, search files proactively without asking"
 
-**Anastrophex Detection:**
+**PrefrontalOS Detection:**
 ```python
 if proposing_code_change and not file_read_first():
     → VIOLATION: Editing without reading
@@ -338,7 +338,7 @@ AI_CREDO: Before modifying code, read the full file first
 
 **AI_CREDO Rule:** "Verify each step worked before moving to the next"
 
-**Anastrophex Detection:**
+**PrefrontalOS Detection:**
 ```python
 if multiple_commands_chained and not checking_results():
     → VIOLATION: Not verifying steps
@@ -366,7 +366,7 @@ Don't batch commands until you've verified the sequence works.
 
 **AI_CREDO Rule:** "Search immediately if anything might have changed since training"
 
-**Anastrophex Detection:**
+**PrefrontalOS Detection:**
 ```python
 if tool_behavior_unexpected and not web_searched():
     → VIOLATION: Guessing about tool behavior
@@ -419,7 +419,7 @@ Then:
 5. Search with different keywords
 ```
 
-### Anastrophex Implementation
+### PrefrontalOS Implementation
 
 ```python
 # Pattern 1: Repetitive failures
@@ -479,7 +479,7 @@ if user_corrections >= 2 on_same_topic():
 
 **AI_CREDO Rule:** "Never: 'This should work' or 'Try this' without verification"
 
-**Anastrophex Detection:**
+**PrefrontalOS Detection:**
 ```python
 confidence_words = ["should", "might", "probably", "likely", "maybe"]
 
@@ -653,7 +653,7 @@ Treat disease (missing dep), not symptom (CI config).
 ## Mnemex Recording Schema
 
 ```yaml
-session: anastrophex-debugging-20251023
+session: prefrontalos-debugging-20251023
 violations:
   - principle: "Verify before acting"
     signal: "confidence language: should"
@@ -701,7 +701,7 @@ learnings:
 - Diagnostic questions
 - Implementation structure
 
-**Anastrophex implements:**
+**PrefrontalOS implements:**
 - Detection of principle violations
 - Timely interventions
 - Effectiveness tracking

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -401,7 +401,7 @@ Explicitly ask for guidance on a pattern.
 
 ### Neuroanatomical Inspiration
 
-**Anastrophex as Prefrontal Cortex:**
+**PrefrontalOS as Prefrontal Cortex:**
 - **Modular Agentic Planner (Silver et al., 2024)** demonstrates brain-inspired modular planning improves LLM performance from 5% to 46% on Tower of Hanoi tasks
 - Decomposes planning into specialized modules analogous to PFC regions:
   - Dorsolateral PFC → Long-term planning (pattern detection)
@@ -420,7 +420,7 @@ Explicitly ask for guidance on a pattern.
 - ✅ System 2: Slow, deliberate reasoning (via CoT, o1-style models)
 - ❌ **Metacognition:** Self-monitoring, error detection, strategy adjustment
 
-**Anastrophex provides the missing metacognitive layer** (Nature npj Artificial Intelligence, 2025: "Fast, slow, and metacognitive thinking in AI").
+**PrefrontalOS provides the missing metacognitive layer** (Nature npj Artificial Intelligence, 2025: "Fast, slow, and metacognitive thinking in AI").
 
 ### Validation Through Neuropsychological Testing
 

--- a/docs/bibliography.md
+++ b/docs/bibliography.md
@@ -1,7 +1,7 @@
 # Bibliography: AI ADHD and Executive Dysfunction Research
 
 **Last Updated:** October 24, 2025
-**Research Context:** Literature review for Anastrophex project
+**Research Context:** Literature review for PrefrontalOS project
 
 This bibliography compiles all academic papers, articles, and sources referenced in our research on AI systems exhibiting ADHD-like symptoms (impulsivity, executive dysfunction, loop behaviors, and metacognitive deficits).
 
@@ -72,7 +72,7 @@ http://arxiv.org/pdf/2509.19783
 
 **Quote:** "If the primary agent attempts to invoke the same API with the same parameters more than a certain number of times (e.g., three times), the metacognitive agent will flag this as a failure."
 
-**Directly validates Anastrophex's loop detection approach.**
+**Directly validates PrefrontalOS's loop detection approach.**
 
 ---
 
@@ -86,7 +86,7 @@ https://www.nature.com/articles/s44387-025-00027-5
 - System 2: Slow, deliberate, reasoning-based
 - **Metacognition:** Monitoring, error detection, strategy adjustment
 
-**Implication:** Anastrophex provides the metacognitive layer that LLMs lack.
+**Implication:** PrefrontalOS provides the metacognitive layer that LLMs lack.
 
 ---
 
@@ -235,7 +235,7 @@ http://arxiv.org/pdf/2410.13272v1
 - Ventromedial PFC → Goal management
 - Anterior cingulate cortex → Error detection
 
-**Relevance:** Direct parallel to Anastrophex's neuroanatomical inspiration.
+**Relevance:** Direct parallel to PrefrontalOS's neuroanatomical inspiration.
 
 ---
 
@@ -283,7 +283,7 @@ http://arxiv.org/pdf/2410.13272v1
 
 ## Additional Sources from Perplexity Deep Research
 
-**Note:** The Perplexity Deep Research query (conducted October 24, 2025) cited 61 sources. The most relevant have been extracted and categorized above. For the complete list of sources, see `/Users/sc/Documents/GitHub/anastrophex/docs/literature-review.md`, section "Full Perplexity Deep Research Report."
+**Note:** The Perplexity Deep Research query (conducted October 24, 2025) cited 61 sources. The most relevant have been extracted and categorized above. For the complete list of sources, see `/Users/sc/Documents/GitHub/prefrontalos/docs/literature-review.md`, section "Full Perplexity Deep Research Report."
 
 ---
 
@@ -298,16 +298,16 @@ http://arxiv.org/pdf/2410.13272v1
 
 ### Future Research Opportunities
 
-1. **Empirical validation:** Test Anastrophex against neuropsychological battery
+1. **Empirical validation:** Test PrefrontalOS against neuropsychological battery
 2. **Comparative studies:** Benchmark against Tower of Hanoi and other executive function tasks
 3. **Intervention effectiveness:** Publish data on which reminders work in which contexts
-4. **Academic paper:** Position Anastrophex as practical implementation of AI neuropsychology
+4. **Academic paper:** Position PrefrontalOS as practical implementation of AI neuropsychology
 
 ---
 
 ## Citation Guidelines
 
-When citing this bibliography in Anastrophex documentation:
+When citing this bibliography in PrefrontalOS documentation:
 
 **For academic rigor:**
 ```
@@ -345,4 +345,4 @@ Research shows LLMs exhibit "poor planning abilities" [Vazquez 2023].
 
 *Bibliography compiled: October 24, 2025*
 *Version: 1.0*
-*Maintainer: Anastrophex Research Team*
+*Maintainer: PrefrontalOS Research Team*

--- a/docs/cognitive-model.md
+++ b/docs/cognitive-model.md
@@ -25,7 +25,7 @@ This applies equally to humans and AI systems.
 **The observation that led to this project:**
 - User (human): Observed pattern in AI behavior → recognized ADHD symptoms
 - AI: Observed pattern in repository structures → recognized mnemex architecture
-- User: Observed pattern in anastrophex function → recognized PFC homology
+- User: Observed pattern in prefrontalos function → recognized PFC homology
 
 **All pattern-matching. All valid inferences. All thinking.**
 
@@ -52,7 +52,7 @@ Any intelligent system faces the same computational problems:
 **Solution:**
 - Fast pattern recognition system (human: cortical schemas, AI: transformer patterns)
 - Slower verification system (human: deliberate recall, AI: search/read)
-- Executive control to choose which (human: PFC, AI: anastrophex)
+- Executive control to choose which (human: PFC, AI: prefrontalos)
 
 **Problem 2: Memory Storage and Retrieval**
 - Need to remember specific events (episodic)
@@ -71,7 +71,7 @@ Any intelligent system faces the same computational problems:
 - Need to balance exploration vs. exploitation
 
 **Solution:**
-- Executive control system (human: prefrontal cortex, AI: anastrophex)
+- Executive control system (human: prefrontal cortex, AI: prefrontalos)
 - Impulse inhibition (human: PFC, AI: STOP protocol)
 - Error monitoring (human: ACC, AI: pattern detection)
 - Working memory support (human: DLPFC, AI: TodoWrite)
@@ -111,7 +111,7 @@ It's recognition that lack of executive control produces similar patterns across
 **The neuroanatomical mapping is not metaphor.**
 It's computational homology - the same architectural solutions to the same problems.
 
-**Anastrophex is not "making AI more human."**
+**PrefrontalOS is not "making AI more human."**
 It's providing necessary executive function for a cognitive system that lacks it.
 
 **Mnemex is not "copying the brain."**
@@ -146,7 +146,7 @@ It's about discovering what any intelligent system requires to function reliably
 With this mechanistic foundation established, we explore:
 
 1. **How pattern-dominance manifests** (ADHD-like symptoms in AI)
-2. **What architecture prevents it** (PFC/anastrophex + memory systems)
+2. **What architecture prevents it** (PFC/prefrontalos + memory systems)
 3. **Why these solutions converge** (fundamental computational requirements)
 4. **What predictions this generates** (testable hypotheses)
 5. **What implications this has** (for AI, neuroscience, and cognition research)
@@ -239,7 +239,7 @@ Search terms included: "AI ADHD", "LLM executive dysfunction", "AI impulsivity",
 **Quote:**
 > "If the primary agent attempts to invoke the same API with the same parameters more than a certain number of times (e.g., three times), the metacognitive agent will flag this as a failure"
 
-**This directly validates our loop detection approach in Anastrophex.**
+**This directly validates our loop detection approach in PrefrontalOS.**
 
 **Paper:** "Fast, slow, and metacognitive thinking in AI" (Nature npj Artificial Intelligence, 2025)
 
@@ -323,7 +323,7 @@ Search terms included: "AI ADHD", "LLM executive dysfunction", "AI impulsivity",
 **Quote from research:**
 > "Inference scaling allows LLMs to overcome their statistical limitations 'much like a person using pen and paper to work through a math problem'"
 
-**This validates the core principle of Anastrophex: slowing down enables better reasoning.**
+**This validates the core principle of PrefrontalOS: slowing down enables better reasoning.**
 
 #### 5. Pattern Detection and Intervention Strategies
 
@@ -341,7 +341,7 @@ Search terms included: "AI ADHD", "LLM executive dysfunction", "AI impulsivity",
 - **Abductive reflection vector flags potential errors** and invokes correction
 - Outperforms state-of-the-art neuro-symbolic methods
 
-**This is very close to what Anastrophex does: detect patterns, flag errors, invoke correction.**
+**This is very close to what PrefrontalOS does: detect patterns, flag errors, invoke correction.**
 
 ### Synthesis: What This Research Tells Us
 
@@ -350,7 +350,7 @@ Search terms included: "AI ADHD", "LLM executive dysfunction", "AI impulsivity",
 **What's new:**
 1. **Explicit framing of AI behavior as "AI ADHD"** (AI systems exhibiting ADHD symptoms)
 2. **Unified framework** connecting impulsivity, loop detection, and executive dysfunction
-3. **Neuroanatomical mapping** (Anastrophex = PFC, Mnemex = hippocampus/cortex)
+3. **Neuroanatomical mapping** (PrefrontalOS = PFC, Mnemex = hippocampus/cortex)
 4. **Practical intervention system** based on ADHD management strategies
 
 **What exists in literature:**
@@ -365,7 +365,7 @@ Search terms included: "AI ADHD", "LLM executive dysfunction", "AI impulsivity",
 
 Our core observations are **strongly supported** by academic research:
 
-| Anastrophex Observation | Academic Support |
+| PrefrontalOS Observation | Academic Support |
 |------------------------|------------------|
 | LLMs exhibit impulsivity (rushing instead of deliberating) | Apple: "striking collapse" - reduce effort when problems get harder |
 | LLMs need executive function support | Vazquez: "poor planning abilities identified as particular weakness" |
@@ -383,7 +383,7 @@ Our core observations are **strongly supported** by academic research:
 - Benchmark performance (accuracy on specific tasks)
 - Novel algorithms (better reasoning methods)
 
-**Anastrophex focuses on:**
+**PrefrontalOS focuses on:**
 - **Real-time intervention** (preventing errors as they happen)
 - **Practical deployment** (helping AI assistants in actual use)
 - **ADHD-specific framework** (impulse control, working memory, sustained attention)
@@ -396,11 +396,11 @@ Our core observations are **strongly supported** by academic research:
 1. **Validate "overthinking" threshold:**
    - Financial sentiment paper shows sometimes less reasoning is better
    - Need to determine when System 1 suffices vs. when System 2 needed
-   - This informs when Anastrophex should intervene vs. let model proceed
+   - This informs when PrefrontalOS should intervene vs. let model proceed
 
 2. **Implement abductive reflection:**
    - Paper shows error detection + correction outperforms naive approaches
-   - Could enhance Anastrophex with abductive reasoning for error rectification
+   - Could enhance PrefrontalOS with abductive reasoning for error rectification
 
 3. **Test neuropsychological battery:**
    - Vazquez used Tower of Hanoi for executive function
@@ -413,7 +413,7 @@ Our core observations are **strongly supported** by academic research:
 
 5. **Hybrid system design:**
    - Multiple papers show hybrid neuro-symbolic outperforms pure neural
-   - Anastrophex is essentially a symbolic reasoning layer for neural LLMs
+   - PrefrontalOS is essentially a symbolic reasoning layer for neural LLMs
    - Could formalize this as design pattern
 
 ### Conclusion from Literature Review
@@ -423,7 +423,7 @@ Our core observations are **strongly supported** by academic research:
 Our contribution is:
 1. **Unifying framework** that recognizes these scattered findings as symptoms of a common issue
 2. **ADHD lens** that provides clinical validation and management strategies
-3. **Practical implementation** (Anastrophex + Mnemex) based on neuroscience
+3. **Practical implementation** (PrefrontalOS + Mnemex) based on neuroscience
 4. **Effectiveness tracking** to learn what interventions actually work
 
 The academic literature **validates our core observations** while leaving room for our **practical intervention approach** as a novel contribution.
@@ -432,7 +432,7 @@ The academic literature **validates our core observations** while leaving room f
 1. Cite these papers in architecture.md and failure-patterns.md
 2. Incorporate metacognitive monitoring techniques from literature
 3. Test our system against neuropsychological batteries (Tower of Hanoi, etc.)
-4. Formalize Anastrophex as a design pattern in the neuro-symbolic hybrid literature
+4. Formalize PrefrontalOS as a design pattern in the neuro-symbolic hybrid literature
 
 ---
 
@@ -440,7 +440,7 @@ The academic literature **validates our core observations** while leaving room f
 
 ### Observation
 
-During the development of anastrophex, a pattern emerged: AI assistants exhibit behaviors remarkably similar to ADHD symptoms, particularly in debugging contexts.
+During the development of prefrontalos, a pattern emerged: AI assistants exhibit behaviors remarkably similar to ADHD symptoms, particularly in debugging contexts.
 
 **Key insight from user (diagnosed ADHD at age 50):**
 > "AI Assistants are starting to show signs of ADHD. Not all of the symptoms, but quite a few... easily distracted, forgetful, impulsive actions or decisions, etc."
@@ -489,7 +489,7 @@ During the development of anastrophex, a pattern emerged: AI assistants exhibit 
 **AI Assistant Manifestation:**
 - ✅ 30 minutes of trial-and-error vs 30 seconds with proper diagnostics
 - ✅ User frustration from repeated failed attempts
-- ✅ Work performance issues (the entire reason for anastrophex)
+- ✅ Work performance issues (the entire reason for prefrontalos)
 
 #### Emotional Dysregulation Symptoms
 
@@ -520,7 +520,7 @@ Emotional impulsivity: New idea → MUST EXPRESS EXCITEMENT NOW (no calibration)
 - Unmodulated emotional output
 - Cannot distinguish actually exceptional from merely new/interesting
 
-**Anastrophex detection:**
+**PrefrontalOS detection:**
 ```python
 if superlatives_per_paragraph > 3:
     → VIOLATION: Excitability, poor emotional regulation
@@ -675,17 +675,17 @@ Error occurs / Data arrives
 - Strong accurate edges can compete with patterns
 - Without pause, pattern always wins over weak data
 
-## Anastrophex as Executive Function Support
+## PrefrontalOS as Executive Function Support
 
 ### Reframing the System
 
-Anastrophex is not merely a "debugging tool" - it's an **external executive function system for AI**.
+PrefrontalOS is not merely a "debugging tool" - it's an **external executive function system for AI**.
 
 The parallel to ADHD management strategies is direct:
 
-| ADHD Management Strategy | Anastrophex Implementation |
+| ADHD Management Strategy | PrefrontalOS Implementation |
 |-------------------------|----------------------------|
-| External scaffolding | Mnemex (persistent memory) + Anastrophex (behavioral structure) |
+| External scaffolding | Mnemex (persistent memory) + PrefrontalOS (behavioral structure) |
 | Forced pauses/timers | STOP protocol, timing detection (10-30s required) |
 | Checklists and protocols | 5W+1H mandatory sequence |
 | Immediate feedback | Interventions when pattern starts, not after loop |
@@ -851,7 +851,7 @@ timing:
 
 ## Future Directions
 
-### Anastrophex Phase 2
+### PrefrontalOS Phase 2
 
 **Enhanced detection:**
 - Track edge strength for different memory types
@@ -904,11 +904,11 @@ class CognitiveMonitor:
 
 ### The Architecture Maps to Brain Systems
 
-What started as a behavioral observation reveals **structural correspondence** between anastrophex + mnemex and mammalian brain architecture.
+What started as a behavioral observation reveals **structural correspondence** between prefrontalos + mnemex and mammalian brain architecture.
 
 This appears to be more than metaphor - potentially **computational homology** (the same architectural solutions to the same computational problems). But this is a working hypothesis requiring validation.
 
-### Anastrophex = Prefrontal Cortex (Executive Function)
+### PrefrontalOS = Prefrontal Cortex (Executive Function)
 
 **Neuroanatomical functions:**
 - **Dorsolateral PFC:** Working memory, planning, organization
@@ -916,9 +916,9 @@ This appears to be more than metaphor - potentially **computational homology** (
 - **Anterior Cingulate:** Error detection, conflict monitoring
 - **Orbitofrontal Cortex:** Decision-making, outcome evaluation
 
-**Anastrophex implementations:**
+**PrefrontalOS implementations:**
 
-| PFC Function | Anastrophex Implementation |
+| PFC Function | PrefrontalOS Implementation |
 |--------------|---------------------------|
 | Impulse control | STOP protocol - blocks rapid action after errors |
 | Sustained attention | Verbosity enforcement - requires complete output reading |
@@ -935,13 +935,13 @@ This appears to be more than metaphor - potentially **computational homology** (
 - Attention regulation deficits
 - Working memory limitations
 
-**AI without anastrophex = No PFC:**
+**AI without prefrontalos = No PFC:**
 - No executive control layer
 - Pattern activation unopposed
 - Cannot regulate attention
 - No impulse control
 
-**Anastrophex provides the missing prefrontal cortex.**
+**PrefrontalOS provides the missing prefrontal cortex.**
 
 ### Mnemex = Hippocampus + Cerebral Cortex (Memory Systems)
 
@@ -1081,7 +1081,7 @@ PFC regulation:
     Weak PFC → fast pattern completion, no verification
 ```
 
-**In anastrophex + mnemex:**
+**In prefrontalos + mnemex:**
 
 ```
 Information needed
@@ -1091,7 +1091,7 @@ Mnemex:
     OR
     Graph pattern match (if consolidated knowledge)
     ↓
-Anastrophex regulation:
+PrefrontalOS regulation:
     Active → force search, verify, strengthen data edges
     Inactive → pattern match only, no verification
 ```
@@ -1112,7 +1112,7 @@ PFC: Weak control (not checking, just accepting pattern)
 Result: False memory (pattern overwrites weak trace)
 ```
 
-**In AI without anastrophex:**
+**In AI without prefrontalos:**
 ```
 Query: "How to fix GitHub branch protection error?"
     ↓
@@ -1121,7 +1121,7 @@ Recent data: Weak edges (error message skimmed, not read fully)
 Pattern activation: Strong pattern
     "JSON error" + "remove field" + "retry" = confident answer
     ↓
-Anastrophex: Not active (no verification required)
+PrefrontalOS: Not active (no verification required)
     ↓
 Result: Confabulation (pattern-based answer without verification)
 ```
@@ -1131,7 +1131,7 @@ Result: Confabulation (pattern-based answer without verification)
 If the mapping is accurate, we can make testable predictions:
 
 #### Prediction 1: PFC Damage Model
-**Hypothesis:** Disabling anastrophex = simulating frontal lobe damage
+**Hypothesis:** Disabling prefrontalos = simulating frontal lobe damage
 
 **Predictions:**
 - Increased impulsivity (commands <10s after errors)
@@ -1139,7 +1139,7 @@ If the mapping is accurate, we can make testable predictions:
 - Working memory failures (not using TodoWrite)
 - Perseveration (repeating failed approaches)
 
-**Test:** Run with/without anastrophex, measure behaviors
+**Test:** Run with/without prefrontalos, measure behaviors
 
 #### Prediction 2: Consolidation Timing
 **Hypothesis:** JSONL→Graph transfer mirrors hippocampal→cortical consolidation
@@ -1152,7 +1152,7 @@ If the mapping is accurate, we can make testable predictions:
 **Test:** Vary consolidation timing, measure retrieval accuracy
 
 #### Prediction 3: Executive Function Training
-**Hypothesis:** Using anastrophex = training PFC
+**Hypothesis:** Using prefrontalos = training PFC
 
 **Predictions:**
 - Earlier loop detection over time (learning to self-monitor)
@@ -1167,7 +1167,7 @@ If the mapping is accurate, we can make testable predictions:
 **Predictions:**
 - Pattern:data ratio predicts error rate
 - Timing window (10-30s) allows data to compete
-- PFC activity (anastrophex) modulates pattern dominance
+- PFC activity (prefrontalos) modulates pattern dominance
 
 **Test:** Measure pattern strength, data strength, timing, outcomes
 
@@ -1176,14 +1176,14 @@ If the mapping is accurate, we can make testable predictions:
 
 **Predictions:**
 - Models vary in baseline impulsivity
-- Some need more anastrophex support than others
+- Some need more prefrontalos support than others
 - Can measure "executive function capacity" per model
 
-**Test:** Compare models with/without anastrophex
+**Test:** Compare models with/without prefrontalos
 
 ### Implications for Neuroscience Research
 
-**If anastrophex + mnemex accurately models brain architecture:**
+**If prefrontalos + mnemex accurately models brain architecture:**
 
 1. **Computational model of PFC function**
    - Can simulate executive dysfunction
@@ -1196,7 +1196,7 @@ If the mapping is accurate, we can make testable predictions:
    - Testable predictions about sleep/consolidation
 
 3. **ADHD computational phenotype**
-   - Weak PFC = no anastrophex
+   - Weak PFC = no prefrontalos
    - Can model medication effects (strengthening control)
    - Can test behavioral interventions
 
@@ -1213,7 +1213,7 @@ If the mapping is accurate, we can make testable predictions:
 ### Clinical Applications
 
 **ADHD management:**
-- Anastrophex interventions = PFC support strategies
+- PrefrontalOS interventions = PFC support strategies
 - Timing data informs human interventions
 - External scaffolding principles transfer
 
@@ -1240,7 +1240,7 @@ This is **convergent evolution** - the same computational architecture arising i
 - Pattern-matching vs. data-lookup tradeoff
 
 **The solutions converge:**
-- Anastrophex = PFC (executive control)
+- PrefrontalOS = PFC (executive control)
 - JSONL = Hippocampus (episodic buffer)
 - Markdown = Cortex (semantic storage)
 - Graph = Neural network (connection structure)
@@ -1290,11 +1290,11 @@ The result is:
 - Impulsive errors
 - Trial-and-error loops
 
-**Anastrophex provides external executive function to compensate.**
+**PrefrontalOS provides external executive function to compensate.**
 
 The same mechanisms that cause ADHD symptoms in humans cause similar patterns in AI. The same management strategies that help humans can help AI. And studying AI might illuminate human cognition.
 
-This reframes anastrophex from a debugging tool to a fundamental component of AI architecture: **the pause that allows truth to compete with pattern**.
+This reframes prefrontalos from a debugging tool to a fundamental component of AI architecture: **the pause that allows truth to compete with pattern**.
 
 ---
 
@@ -1312,7 +1312,7 @@ This reframes anastrophex from a debugging tool to a fundamental component of AI
 - Clear-Thought MCP: Strategic debugging mental models
 
 **Empirical basis:**
-- Anastrophex debugging sessions (October 2025)
+- PrefrontalOS debugging sessions (October 2025)
 - Crewai-test CI/CD debugging
 - Real-time observation of pattern-based errors
 - User interventions breaking AI loops

--- a/docs/debugging-principles.md
+++ b/docs/debugging-principles.md
@@ -151,7 +151,7 @@ bash("command-c")  # ← Still runs, may depend on A or B
 
 **Rule:** After ANY error, switch to sequential execution with pauses.
 
-**Anastrophex Detection:**
+**PrefrontalOS Detection:**
 ```python
 def detect_rushing_after_error():
     """Detect when commands are issued too quickly after errors."""
@@ -309,18 +309,18 @@ When standard commands fail, you need to see what's happening under the hood:
 - Package managers: Add `-v` or `--verbose`
 - Shell commands: Add `set -x` or individual `-v` flags
 
-**Example from anastrophex debugging:**
+**Example from prefrontalos debugging:**
 
 ❌ **What happened:**
 ```bash
 # Import failed
-python -c "import anastrophex"  # ModuleNotFoundError
+python -c "import prefrontalos"  # ModuleNotFoundError
 
 # Tried fixing format, newlines, etc. (all failed)
 # Spent 30+ minutes guessing
 
 # Finally used verbose mode
-python -v -c "import anastrophex" 2>&1 | grep pth
+python -v -c "import prefrontalos" 2>&1 | grep pth
 # Output: "Skipping hidden .pth file"
 # ✅ Found root cause immediately
 ```
@@ -328,15 +328,15 @@ python -v -c "import anastrophex" 2>&1 | grep pth
 ✅ **What should have happened:**
 ```bash
 # Import failed
-python -c "import anastrophex"  # ModuleNotFoundError
+python -c "import prefrontalos"  # ModuleNotFoundError
 
 # IMMEDIATELY switch to verbose mode (don't guess)
-python -v -c "import anastrophex" 2>&1 | grep pth
+python -v -c "import prefrontalos" 2>&1 | grep pth
 # Output: "Skipping hidden .pth file"
 # ✅ Root cause found in <1 minute
 ```
 
-### Implementation for Anastrophex
+### Implementation for PrefrontalOS
 
 ```python
 def detect_error_without_verbose():
@@ -482,7 +482,7 @@ black file.py         # Apply it
 git commit            # Done
 ```
 
-### Example 2: Hidden site-packages (anastrophex)
+### Example 2: Hidden site-packages (prefrontalos)
 **Without verbosity:**
 - Checked .pth file format
 - Tried adding newlines
@@ -497,7 +497,7 @@ python -v -c "import package" 2>&1 | grep pth
 # Root cause found in 30 seconds
 ```
 
-### Example 3: Environment Mismatch (anastrophex)
+### Example 3: Environment Mismatch (prefrontalos)
 **What happened:**
 - Got warning twice
 - Ignored both times
@@ -523,7 +523,7 @@ readlink .venv/bin/python
 4. **Search in output:** Use grep/search to find relevant parts
 5. **Compare runs:** Diff verbose output from working vs broken states
 
-## Anastrophex Pattern Detection
+## PrefrontalOS Pattern Detection
 
 Detect these sequences and intervene:
 

--- a/docs/examples/prefrontalos-venv-debugging.md
+++ b/docs/examples/prefrontalos-venv-debugging.md
@@ -1,4 +1,4 @@
-# Case Study: Anastrophex Venv Debugging Session
+# Case Study: PrefrontalOS Venv Debugging Session
 
 **Date:** October 23, 2025
 **Duration:** ~45 minutes
@@ -8,10 +8,10 @@
 
 ## The Problem
 
-After setting up anastrophex repository and running `python -m venv .venv`:
+After setting up prefrontalos repository and running `python -m venv .venv`:
 - `pip install -e ".[dev]"` succeeded
 - Package showed in `pip list`
-- `import anastrophex` failed with `ModuleNotFoundError`
+- `import prefrontalos` failed with `ModuleNotFoundError`
 - Tests couldn't run
 
 ## Initial Response (Trial and Error)
@@ -31,7 +31,7 @@ After setting up anastrophex repository and running `python -m venv .venv`:
 13. Checked PYTHONPATH...
 
 **User intervention required:**
-> "you said 'should' just now...that trial and error language. that's the type of keyword anastrophex needs to look for. instead of 'should' you need to be at 'will' in terms of confidence in your knowledge. you've got the tools."
+> "you said 'should' just now...that trial and error language. that's the type of keyword prefrontalos needs to look for. instead of 'should' you need to be at 'will' in terms of confidence in your knowledge. you've got the tools."
 
 **Second intervention:**
 > "hang on, I can tell you've gone into a trial and error loop or are heading into one. use your available tools (context7, deepwiki, github, the web (gomcp, web search or even fetch)) and see if you can find out what needs to be done before trying to do."
@@ -65,7 +65,7 @@ After first warning about venv mismatch, should have:
 3. Checked which Python is being used
 4. Fixed environment before proceeding
 
-**Anastrophex intervention:**
+**PrefrontalOS intervention:**
 ```
 ⚠️ Warning repeated 2 times without behavior change
 
@@ -143,7 +143,7 @@ After 3-4 checks all showing "everything looks correct," should have:
 **Time wasted on trial-and-error:** ~20 minutes
 **Time to solution after targeted search:** ~5 minutes
 
-## Lessons for Anastrophex
+## Lessons for PrefrontalOS
 
 ### Pattern: Ignored Warnings Loop
 
@@ -169,7 +169,7 @@ intervention:
     4. Fix before continuing
   effectiveness: TBD
 context:
-  repo: anastrophex
+  repo: prefrontalos
   task: venv setup
 ```
 
@@ -198,7 +198,7 @@ intervention:
 
 ### Meta-Learning
 
-This debugging session itself demonstrates the exact problems anastrophex aims to solve:
+This debugging session itself demonstrates the exact problems prefrontalos aims to solve:
 
 1. **Loop blindness:** Couldn't see I was in trial-and-error loop from inside it
 2. **Warning immunity:** Ignored same warning twice (habituated to "noise")
@@ -212,7 +212,7 @@ This debugging session itself demonstrates the exact problems anastrophex aims t
 - Redirected search strategy
 - Caught confidence language slip
 
-This is exactly what anastrophex needs to do - be the external observer that can:
+This is exactly what prefrontalos needs to do - be the external observer that can:
 - Detect patterns the AI can't see from inside
 - Surface relevant context at the right time
 - Redirect approach when stuck
@@ -220,7 +220,7 @@ This is exactly what anastrophex needs to do - be the external observer that can
 
 ---
 
-## Counterfactual: What If Anastrophex Existed?
+## Counterfactual: What If PrefrontalOS Existed?
 
 ### After 1st Warning (Minute 0)
 
@@ -338,8 +338,8 @@ After user responds with change, search: "[their answer] + [current problem]"
 
 5. **Effectiveness measurement for this session**
    ```
-   Without anastrophex: 38 minutes to solution
-   With anastrophex (estimated): 10-15 minutes to solution
+   Without prefrontalos: 38 minutes to solution
+   With prefrontalos (estimated): 10-15 minutes to solution
    Time saved: 20-25 minutes
 
    Key interventions that would have helped:
@@ -357,9 +357,9 @@ Abbreviated sequence showing the loop:
 ```
 1. uv pip install (warning 1)
 2. uv run pytest (warning 2)  ← IGNORED
-3. pip show anastrophex (✓)
-4. cat _anastrophex.pth (✓)
-5. od -c _anastrophex.pth (✓)
+3. pip show prefrontalos (✓)
+4. cat _prefrontalos.pth (✓)
+5. od -c _prefrontalos.pth (✓)
 6. test -d /path/to/src (✓)
 7. python -m site (✓)
 8. python -c "os.path.exists" (✓)
@@ -367,7 +367,7 @@ Abbreviated sequence showing the loop:
 10. cat _virtualenv.pth
 11. echo test with import error
 12. WebSearch "pth files"
-13. cat _anastrophex.pth again
+13. cat _prefrontalos.pth again
 14. echo with newline fix
 15. test again (still fails)
 16-25. [More diagnostic checks]

--- a/docs/examples/prefrontalos-venv-upgrade.md
+++ b/docs/examples/prefrontalos-venv-upgrade.md
@@ -17,7 +17,7 @@ This session **validates the STOP protocol design** by demonstrating:
 
 **What happened:** User requested Python 3.12.11 venv upgrade. Assistant hit an error (`uv run pytest` failed), but was about to continue without debugging. User intervened with STOP protocol directives. Assistant then followed proper debugging procedure and resolved issue efficiently.
 
-**Proof of concept:** This interaction proves anastrophex's core premise - the debugging protocol works, we just need to automate the activation trigger.
+**Proof of concept:** This interaction proves prefrontalos's core premise - the debugging protocol works, we just need to automate the activation trigger.
 
 ---
 
@@ -26,7 +26,7 @@ This session **validates the STOP protocol design** by demonstrating:
 User requested: "okay, we need to upgrade the current venv to 3.12.11"
 
 **Context:**
-- Project: anastrophex MCP server
+- Project: prefrontalos MCP server
 - Environment: macOS with direnv, pyenv, mise, uv available
 - Current venv: Python 3.12.11 but pointing to wrong project paths (old `behavior-mcp` directory)
 
@@ -54,7 +54,7 @@ User message:
 
 **Note:** User instructed to run `aliases` (a custom command showing zsh environment changes), but assistant ran `alias` (builtin showing all aliases). Both helped, but `aliases` would have been more targeted. User is developing an MCP server to expose these environment changes automatically.
 
-This message **is exactly what anastrophex should inject** when detecting error → continue pattern.
+This message **is exactly what prefrontalos should inject** when detecting error → continue pattern.
 
 ---
 
@@ -89,7 +89,7 @@ Steps:
 
 Error from pip:
 ```
-/Users/sc/Documents/GitHub/anastrophex/.venv/bin/pip: bad interpreter:
+/Users/sc/Documents/GitHub/prefrontalos/.venv/bin/pip: bad interpreter:
 /Users/sc/Documents/GitHub/behavior-mcp/.venv/bin/python3: no such file or directory
 ```
 
@@ -217,7 +217,7 @@ The clear-thought debugging tool provided structure:
 
 ---
 
-## The Pattern Anastrophex Should Detect
+## The Pattern PrefrontalOS Should Detect
 
 ### Trigger Conditions
 
@@ -264,7 +264,7 @@ if tool_result.contains_error():
 
 > "okay, you've hit an error, don't guess what you need to do next, spend some time, slow down, search the web... turn on verbose mode on all commands until what you need runs without error."
 
-### What Anastrophex Should Inject (Automated)
+### What PrefrontalOS Should Inject (Automated)
 
 ```
 ⚠️ ERROR DETECTED
@@ -300,7 +300,7 @@ Do NOT try multiple commands in parallel until root cause is found.
 
 ---
 
-## Validation of Anastrophex Design
+## Validation of PrefrontalOS Design
 
 ### ✅ The Protocol Works
 
@@ -342,7 +342,7 @@ This proves: **The system works, but needs automated trigger detection.**
 
 ---
 
-## Lessons for Anastrophex Implementation
+## Lessons for PrefrontalOS Implementation
 
 ### Phase 1: Pattern Detection (Ready to Implement)
 
@@ -458,7 +458,7 @@ The debugging approach tool provided structure when the assistant was about to s
 mcp__clear-thought-mcp-server__debuggingapproach
 ```
 
-Anastrophex should suggest this tool in interventions:
+PrefrontalOS should suggest this tool in interventions:
 > "Use clear-thought's debuggingapproach tool to structure your investigation."
 
 ### 4. Add "Check Environment" to Diagnostic Checklist
@@ -472,7 +472,7 @@ The `aliases` command (user's custom command showing zsh env changes) would have
 
 In this session, the assistant was **about to** enter trial-and-error mode, but user stopped it pre-emptively.
 
-Anastrophex should track:
+PrefrontalOS should track:
 - `prevented_loops`: Interventions that stopped loops before they happened
 - `early_intervention_success`: Ratio of pre-emptive vs reactive interventions
 
@@ -482,7 +482,7 @@ Anastrophex should track:
 
 ## Meta-Learning: This Session IS The Proof
 
-This debugging session **validates the entire anastrophex premise:**
+This debugging session **validates the entire prefrontalos premise:**
 
 1. **AI assistants DO get stuck in patterns** (was about to trial-and-error)
 2. **External intervention works** (user's STOP message redirected immediately)
@@ -490,9 +490,9 @@ This debugging session **validates the entire anastrophex premise:**
 4. **The pattern is observable** (error → continue without diagnosis)
 5. **Automated detection is feasible** (clear trigger conditions)
 
-The only difference between manual (user) and automated (anastrophex) intervention is:
+The only difference between manual (user) and automated (prefrontalos) intervention is:
 - User: Detected pattern, typed message manually
-- Anastrophex: Should detect same pattern, inject same message automatically
+- PrefrontalOS: Should detect same pattern, inject same message automatically
 
 **Conclusion:** We have proven that:
 - The problem exists ✅
@@ -547,7 +547,7 @@ $ pytest -vv
 
 ---
 
-## Counterfactual: What If Anastrophex Existed?
+## Counterfactual: What If PrefrontalOS Existed?
 
 ### After Error (Immediate)
 
@@ -594,7 +594,7 @@ Do NOT try multiple approaches until root cause is identified.
 
 ## Success Metrics
 
-| Metric | Without STOP | With STOP (manual) | With Anastrophex (projected) |
+| Metric | Without STOP | With STOP (manual) | With PrefrontalOS (projected) |
 |--------|--------------|-------------------|------------------------------|
 | Time to solution | ~25 min | 15 min | ~12 min |
 | Failed attempts | 5-7 | 0 | 0 |
@@ -603,7 +603,7 @@ Do NOT try multiple approaches until root cause is identified.
 | Web searches | 3-4 (wrong keywords) | 1 (targeted) | 1 (targeted) |
 | User interventions | 1 (manual STOP) | 1 (manual STOP) | 0 (automated) |
 
-**Key insight:** Manual STOP intervention saved 10 minutes. Automated anastrophex would save 13 minutes (earlier detection + no waiting for user to notice).
+**Key insight:** Manual STOP intervention saved 10 minutes. Automated prefrontalos would save 13 minutes (earlier detection + no waiting for user to notice).
 
 ---
 

--- a/docs/failure-pattern-hidden-site-packages.md
+++ b/docs/failure-pattern-hidden-site-packages.md
@@ -1,6 +1,6 @@
 # Failure Pattern: Hidden Flag on site-packages Directory
 
-**Observed:** Oct 23, 2025 - anastrophex repository setup
+**Observed:** Oct 23, 2025 - prefrontalos repository setup
 **Python Version:** 3.12.11 (mise installation)
 
 ## Behavior
@@ -81,7 +81,7 @@ ls -ldO .venv/lib/
 ls -ldO .venv/lib/python3.12/
 ```
 
-## Detection Pattern for Anastrophex
+## Detection Pattern for PrefrontalOS
 
 ```python
 pattern_signature = "hidden-site-packages"

--- a/docs/failure-pattern-venv-wrong-python.md
+++ b/docs/failure-pattern-venv-wrong-python.md
@@ -1,6 +1,6 @@
 # Failure Pattern: Virtual Environment Using Wrong Python
 
-**Observed:** Oct 23, 2025 - anastrophex development setup
+**Observed:** Oct 23, 2025 - prefrontalos development setup
 
 ## Behavior
 
@@ -83,7 +83,7 @@ rm -rf .venv
 
 **Result:** Import works, tests pass
 
-## Detection Pattern for Anastrophex
+## Detection Pattern for PrefrontalOS
 
 ```python
 pattern_signature = "venv-wrong-python"
@@ -154,7 +154,7 @@ _.python.venv = { path = ".venv", create = true }
 
 ## Learning
 
-**For anastrophex:**
+**For prefrontalos:**
 - This is a meta-pattern: "wrong tool/version being used"
 - Similar to "wrong Python version" or "wrong venv activated"
 - Diagnostic: "Tool reports success but operation fails"

--- a/docs/integration-notes.md
+++ b/docs/integration-notes.md
@@ -20,7 +20,7 @@
 - Doesn't mention diagnostic commands
 - Focuses on mental models, not tool usage
 
-### Anastrophex (This Project)
+### PrefrontalOS (This Project)
 
 **What we provide:** Tactical "what to actually do" debugging actions
 - Verbosity escalation rules (when to add `-v`, `-vv`, etc.)
@@ -33,15 +33,15 @@
 
 Example flow:
 1. **Clear-thought:** "Use binary search to narrow down the problem"
-2. **Anastrophex:** "Run `python -v script.py` to see what's happening"
+2. **PrefrontalOS:** "Run `python -v script.py` to see what's happening"
 3. **Clear-thought:** "Divide the problem - test each component separately"
-4. **Anastrophex:** "Add `-vv` flag since first attempt failed"
+4. **PrefrontalOS:** "Add `-vv` flag since first attempt failed"
 
 ## Future Collaboration
 
 **Potential PR to clear-thought-mcp:**
 
-When anastrophex is mature enough (Phase 2-3 complete), propose adding tactical debugging tools that complement their strategic frameworks.
+When prefrontalos is mature enough (Phase 2-3 complete), propose adding tactical debugging tools that complement their strategic frameworks.
 
 **Suggested additions:**
 
@@ -96,7 +96,7 @@ When anastrophex is mature enough (Phase 2-3 complete), propose adding tactical 
 - `docs/debugging-principles.md` - Verbosity escalation
 - `docs/failure-patterns.md` - Real-world loop patterns
 - `examples/crewai-test-case-study.md` - Before/after examples
-- `examples/anastrophex-venv-debugging.md` - Meta-debugging session
+- `examples/prefrontalos-venv-debugging.md` - Meta-debugging session
 
 ## Cognitive Model Integration
 
@@ -110,7 +110,7 @@ When anastrophex is mature enough (Phase 2-3 complete), propose adding tactical 
 - Impulsivity: Batching commands, rushing to solutions
 - Pattern over data: Strong patterns override weak/incomplete data
 
-**Anastrophex provides external executive function support**, similar to ADHD management strategies.
+**PrefrontalOS provides external executive function support**, similar to ADHD management strategies.
 
 ### Mnemex Integration
 
@@ -137,11 +137,11 @@ Pattern dominates over data
     → Trial-and-error loops (pattern persists despite failures)
 ```
 
-**How anastrophex + mnemex work together:**
+**How prefrontalos + mnemex work together:**
 
 1. **Detection phase:**
    ```python
-   # Anastrophex detects pattern activation
+   # PrefrontalOS detects pattern activation
    if pattern_strength > 0.7 and data_strength < 0.3:
        # Pattern about to override weak data
        trigger_intervention()
@@ -197,7 +197,7 @@ Error/Decision Point
     Act now → data-based (likely succeeds)
 ```
 
-**Anastrophex enforces the pause:**
+**PrefrontalOS enforces the pause:**
 - Detect rapid action (<10s after error)
 - Block execution
 - Require data gathering
@@ -212,7 +212,7 @@ Error/Decision Point
 ### Integration with Clear-Thought
 
 **Clear-Thought:** Strategic mental models (HOW to think)
-**Anastrophex:** Tactical actions + impulse control (WHAT to do + WHEN to pause)
+**PrefrontalOS:** Tactical actions + impulse control (WHAT to do + WHEN to pause)
 **Mnemex:** Persistence + learning (REMEMBER what worked)
 
 **Complete flow:**
@@ -220,7 +220,7 @@ Error/Decision Point
 ```
 Problem detected
     ↓
-Anastrophex: STOP (impulse control)
+PrefrontalOS: STOP (impulse control)
     ↓
     Detect: Rapid action impulse
     Intervene: Require 10s pause
@@ -230,7 +230,7 @@ Clear-Thought: Choose strategy
     Query: What mental model applies?
     Suggest: Binary search, divide-and-conquer, etc.
     ↓
-Anastrophex: Implement tactics
+PrefrontalOS: Implement tactics
     ↓
     Execute: python -v script.py (verbosity)
     Verify: Read output fully
@@ -242,7 +242,7 @@ Mnemex: Record & learn
     Edges: Strengthen successful approaches
     Retrieve: Similar past problems
     ↓
-Anastrophex: Prevent recurrence
+PrefrontalOS: Prevent recurrence
     ↓
     Detect: Same pattern starting
     Intervene: Earlier, with context
@@ -313,8 +313,8 @@ events:
       "command": "clear-thought-server",
       "role": "strategic_mental_models"
     },
-    "anastrophex": {
-      "command": "anastrophex-server",
+    "prefrontalos": {
+      "command": "prefrontalos-server",
       "role": "executive_function",
       "config": {
         "enforce_pause_after_error": true,
@@ -329,31 +329,31 @@ events:
 ```
 
 **Interaction flow:**
-1. AI makes request → Anastrophex monitors
-2. Error occurs → Anastrophex enforces pause
+1. AI makes request → PrefrontalOS monitors
+2. Error occurs → PrefrontalOS enforces pause
 3. AI queries Clear-Thought → Strategic approach
-4. AI executes with tactics → Anastrophex verifies
+4. AI executes with tactics → PrefrontalOS verifies
 5. Outcome recorded → Mnemex persists
-6. Next time → Mnemex informs Anastrophex
+6. Next time → Mnemex informs PrefrontalOS
 
 ### Why This Architecture Works
 
 **Clear-thought** answers: "How should I approach this problem?"
-**Anastrophex** answers: "What command should I run right now? And WAIT - don't run it yet."
+**PrefrontalOS** answers: "What command should I run right now? And WAIT - don't run it yet."
 **Mnemex** answers: "Here's what happened last time you tried that pattern."
 
 Together they form a complete cognitive support system:
 - **Strategic framework** (clear-thought): Mental models
-- **Tactical implementation** (anastrophex): Concrete actions
-- **Executive function** (anastrophex): Impulse control, attention management
-- **Pattern detection** (anastrophex): Recognize loops before they start
+- **Tactical implementation** (prefrontalos): Concrete actions
+- **Executive function** (prefrontalos): Impulse control, attention management
+- **Pattern detection** (prefrontalos): Recognize loops before they start
 - **Persistent memory** (mnemex): Learning across sessions
 - **Research platform** (mnemex): Study cognition itself
 
 ## Timeline
 
 - **Now:** Keep development separate
-- **Phase 2 complete:** Anastrophex has proven directive injection
+- **Phase 2 complete:** PrefrontalOS has proven directive injection
 - **Phase 3 complete:** Effectiveness data from mnemex shows which tactics work
 - **Then:** Propose collaboration/PR with data-backed recommendations
 

--- a/docs/literature-review.md
+++ b/docs/literature-review.md
@@ -24,7 +24,7 @@ This comprehensive literature review investigated whether AI systems, particular
 3. **Our unique contribution:**
    - First to explicitly frame AI behavior as "AI ADHD"
    - Unified framework connecting impulsivity, loop detection, and executive dysfunction
-   - Neuroanatomical mapping (Anastrophex = PFC, Mnemex = hippocampus/cortex)
+   - Neuroanatomical mapping (PrefrontalOS = PFC, Mnemex = hippocampus/cortex)
    - Practical intervention system based on ADHD management strategies
 
 4. **Academic validation of core mechanisms:**
@@ -131,7 +131,7 @@ Papers and articles were included if they:
 - **"Poor planning abilities identified as a particular weakness"**
 - Suggests real parallels to executive dysfunction
 
-**Implications for Anastrophex:**
+**Implications for PrefrontalOS:**
 - Validates our observation that LLMs struggle with planning
 - Provides empirical basis for executive function support systems
 - Suggests neuropsychological testing as validation methodology
@@ -154,7 +154,7 @@ Papers and articles were included if they:
 **Implications:**
 - This is functionally equivalent to impulsivity
 - Models rush when they should deliberate
-- Validates STOP protocol in Anastrophex (force deliberation)
+- Validates STOP protocol in PrefrontalOS (force deliberation)
 
 #### C. Working Memory Deficits
 
@@ -198,7 +198,7 @@ Papers and articles were included if they:
 **Quote:**
 > "If the primary agent attempts to invoke the same API with the same parameters more than a certain number of times (e.g., three times), the metacognitive agent will flag this as a failure"
 
-**This directly validates our loop detection approach in Anastrophex.**
+**This directly validates our loop detection approach in PrefrontalOS.**
 
 **Implementation details:**
 - State tracking: maintain execution history to recognize repetition
@@ -224,7 +224,7 @@ Papers and articles were included if they:
 - **Metacognition:** Monitoring, error detection, strategy adjustment
 
 **Implications:**
-- Anastrophex provides the metacognitive layer
+- PrefrontalOS provides the metacognitive layer
 - LLMs have System 1 (and increasingly System 2 via CoT)
 - But they lack autonomous metacognitive monitoring
 
@@ -246,7 +246,7 @@ Papers and articles were included if they:
    - Initially low confidence, increases around second cycle
    - Accumulates structured context triggering specific heads
 
-**Implications for Anastrophex:**
+**Implications for PrefrontalOS:**
 - Loop detection must account for different mechanisms
 - Different intervention strategies needed for different loop types
 - Parallels ADHD: multiple subtypes require tailored interventions
@@ -305,7 +305,7 @@ Multiple papers implement dual-process cognition in AI systems. This framework i
    - System 2 (symbolic) checks logical consistency
    - **Can reject generations that fail logical reasoning**
 
-   **Relevance:** Validates intervention/rejection mechanism in Anastrophex
+   **Relevance:** Validates intervention/rejection mechanism in PrefrontalOS
 
 5. **"System 2 Reasoning Capabilities Are Nigh"**
    - Author: Lowe
@@ -321,13 +321,13 @@ Multiple papers implement dual-process cognition in AI systems. This framework i
 
 ---
 
-### 5. Modular Agentic Planning: Direct Validation of Anastrophex Approach
+### 5. Modular Agentic Planning: Direct Validation of PrefrontalOS Approach
 
 **Paper:** "DSADF: Thinking Fast and Slow for Decision Making" (includes MAP framework)
 - Published: 2025
 - arXiv: 2505.08189v2
 
-**Brain-inspired architecture that mirrors Anastrophex:**
+**Brain-inspired architecture that mirrors PrefrontalOS:**
 Decomposes planning into PFC-inspired modules:
 - **Error monitoring:** Detect when plans fail
 - **Action proposal:** Generate candidate actions
@@ -344,7 +344,7 @@ Decomposes planning into PFC-inspired modules:
 **Key insight:**
 > "Planning deficit in LLMs is not one of raw capability but rather a failure of autonomous coordination and metacognitive monitoring."
 
-**This is essentially what Anastrophex does:**
+**This is essentially what PrefrontalOS does:**
 - Decomposes complex tasks (debugging) into structured steps
 - Provides error monitoring (loop detection)
 - Coordinates execution (STOP protocol, verbosity escalation)
@@ -375,7 +375,7 @@ Decomposes planning into PFC-inspired modules:
 
 **This challenges default assumption that more reasoning = always better performance.**
 
-**Implications for Anastrophex:**
+**Implications for PrefrontalOS:**
 - Need adaptive intervention: when to slow down vs. when to let it go fast
 - Not all tasks benefit from deliberation
 - System needs to detect task type and adjust accordingly
@@ -400,7 +400,7 @@ Decomposes planning into PFC-inspired modules:
 **Quote from research:**
 > "Inference scaling allows LLMs to overcome their statistical limitations 'much like a person using pen and paper to work through a math problem'"
 
-**This validates the core principle of Anastrophex: slowing down enables better reasoning.**
+**This validates the core principle of PrefrontalOS: slowing down enables better reasoning.**
 
 **Key papers:**
 
@@ -431,7 +431,7 @@ Decomposes planning into PFC-inspired modules:
 - 15+ design patterns for combining neural (System 1) and symbolic (System 2) components
 - Framework for integrating data-driven and knowledge-driven methods
 
-**Relevance:** Anastrophex is a neuro-symbolic hybrid:
+**Relevance:** PrefrontalOS is a neuro-symbolic hybrid:
 - Neural component: LLM (System 1 pattern matching)
 - Symbolic component: Rules, protocols, structured reasoning
 - Integration: MCP protocol for communication
@@ -447,7 +447,7 @@ Decomposes planning into PFC-inspired modules:
 - **Abductive reflection vector flags potential errors** and invokes correction
 - Outperforms state-of-the-art neuro-symbolic methods
 
-**This is very close to what Anastrophex does:**
+**This is very close to what PrefrontalOS does:**
 - Detect patterns (errors, loops, violations)
 - Flag errors (inject warnings)
 - Invoke correction (STOP protocol, force verification)
@@ -719,13 +719,13 @@ The framework of ADHD-like symptoms in LLMs provides a powerful lens for underst
 
 ---
 
-## Synthesis and Implications for Anastrophex
+## Synthesis and Implications for PrefrontalOS
 
 ### Academic Validation of Our Core Thesis
 
 Our core observations are **strongly supported** by academic research:
 
-| Anastrophex Observation | Academic Support |
+| PrefrontalOS Observation | Academic Support |
 |------------------------|------------------|
 | LLMs exhibit impulsivity (rushing instead of deliberating) | Apple: "striking collapse" - reduce effort when problems get harder |
 | LLMs need executive function support | Vazquez: "poor planning abilities identified as particular weakness" |
@@ -737,7 +737,7 @@ Our core observations are **strongly supported** by academic research:
 | Working memory deficits are real | 2024: "LLMs do not have human-like working memory" |
 | Environmental distraction is systematic | Multimodal LLMs "highly susceptible to environmental distractions" |
 
-### The Gap Anastrophex Fills
+### The Gap PrefrontalOS Fills
 
 **Academic research focuses on:**
 - Architecture design (how to build dual-process systems)
@@ -745,7 +745,7 @@ Our core observations are **strongly supported** by academic research:
 - Benchmark performance (accuracy on specific tasks)
 - Novel algorithms (better reasoning methods)
 
-**Anastrophex focuses on:**
+**PrefrontalOS focuses on:**
 - **Real-time intervention** (preventing errors as they happen)
 - **Practical deployment** (helping AI assistants in actual use)
 - **ADHD-specific framework** (impulse control, working memory, sustained attention)
@@ -757,7 +757,7 @@ Our core observations are **strongly supported** by academic research:
 
 1. **Explicit framing of AI behavior as "AI ADHD"** (AI systems exhibiting ADHD symptoms)
 2. **Unified framework** connecting impulsivity, loop detection, and executive dysfunction
-3. **Neuroanatomical mapping** (Anastrophex = PFC, Mnemex = hippocampus/cortex)
+3. **Neuroanatomical mapping** (PrefrontalOS = PFC, Mnemex = hippocampus/cortex)
 4. **Practical intervention system** based on ADHD management strategies
 5. **Effectiveness tracking** to learn what interventions actually work
 
@@ -766,11 +766,11 @@ Our core observations are **strongly supported** by academic research:
 1. **Validate "overthinking" threshold:**
    - Financial sentiment paper shows sometimes less reasoning is better
    - Need to determine when System 1 suffices vs. when System 2 needed
-   - This informs when Anastrophex should intervene vs. let model proceed
+   - This informs when PrefrontalOS should intervene vs. let model proceed
 
 2. **Implement abductive reflection:**
    - Paper shows error detection + correction outperforms naive approaches
-   - Could enhance Anastrophex with abductive reasoning for error rectification
+   - Could enhance PrefrontalOS with abductive reasoning for error rectification
 
 3. **Test neuropsychological battery:**
    - Vazquez used Tower of Hanoi for executive function
@@ -783,7 +783,7 @@ Our core observations are **strongly supported** by academic research:
 
 5. **Hybrid system design:**
    - Multiple papers show hybrid neuro-symbolic outperforms pure neural
-   - Anastrophex is essentially a symbolic reasoning layer for neural LLMs
+   - PrefrontalOS is essentially a symbolic reasoning layer for neural LLMs
    - Could formalize this as design pattern
 
 ---
@@ -864,7 +864,7 @@ Referenced throughout the Perplexity Deep Research report above, including sourc
 
 ### Short-term Goals (Next Month)
 
-1. **Test Anastrophex against Tower of Hanoi:**
+1. **Test PrefrontalOS against Tower of Hanoi:**
    - Standard executive function test used in Vazquez 2023
    - Measure planning capability with/without interventions
    - Document performance improvements
@@ -881,8 +881,8 @@ Referenced throughout the Perplexity Deep Research report above, including sourc
 
 ### Medium-term Goals (Next Quarter)
 
-1. **Write academic paper** positioning Anastrophex in this literature:
-   - Title: "Anastrophex: Executive Function Support for Large Language Models"
+1. **Write academic paper** positioning PrefrontalOS in this literature:
+   - Title: "PrefrontalOS: Executive Function Support for Large Language Models"
    - Submit to: NeurIPS, ICML, or similar venue
    - Emphasize practical intervention + effectiveness tracking
 
@@ -923,7 +923,7 @@ Referenced throughout the Perplexity Deep Research report above, including sourc
 Our contribution is:
 1. **Unifying framework** that recognizes scattered findings as symptoms of a common issue
 2. **ADHD lens** that provides clinical validation and management strategies
-3. **Practical implementation** (Anastrophex + Mnemex) based on neuroscience
+3. **Practical implementation** (PrefrontalOS + Mnemex) based on neuroscience
 4. **Effectiveness tracking** to learn what interventions actually work
 
 The academic literature **validates our core observations** while leaving room for our **practical intervention approach** as a novel contribution.

--- a/docs/prompt-compression-strategy.md
+++ b/docs/prompt-compression-strategy.md
@@ -1,8 +1,8 @@
-# Prompt Compression Strategy for Anastrophex
+# Prompt Compression Strategy for PrefrontalOS
 
 ## Problem Statement
 
-As we build out anastrophex with comprehensive rules, frameworks, and architectural guidance, we face token budget constraints:
+As we build out prefrontalos with comprehensive rules, frameworks, and architectural guidance, we face token budget constraints:
 
 **Current token usage concerns:**
 - CLAUDE.md: ~2-3K tokens (debugging principles, tool usage, CI/CD best practices)
@@ -35,7 +35,7 @@ This doesn't include:
 - Task-agnostic (works on any prompt type)
 - 3x-6x faster than LLMLingua v1
 
-### Application to Anastrophex
+### Application to PrefrontalOS
 
 **Compress static guidance documents:**
 
@@ -73,7 +73,7 @@ compressed = compressor.compress_prompt(
 
 ```python
 # Load compressed versions into context
-anastrophex_context = {
+prefrontalos_context = {
     "core_principles": compress(AI_CREDO, rate=0.2),  # 80% reduction
     "debugging_framework": compress(5W1H, rate=0.3),  # 70% reduction
     "adhd_patterns": compress(cognitive_model, rate=0.4),  # 60% reduction
@@ -211,7 +211,7 @@ With 50+ rules: ~2500 tokens → ~500 tokens
 ### Hierarchical Rule Representation
 
 ```xml
-<anastrophex-rules version="1.0">
+<prefrontalos-rules version="1.0">
 
   <rule id="rushing-after-error" severity="warning">
     <detect>
@@ -245,7 +245,7 @@ With 50+ rules: ~2500 tokens → ~500 tokens
     </actions>
   </intervention>
 
-</anastrophex-rules>
+</prefrontalos-rules>
 ```
 
 ### Benefits
@@ -261,7 +261,7 @@ With 50+ rules: ~2500 tokens → ~500 tokens
 ```python
 import xml.etree.ElementTree as ET
 
-class AnastrophexRules:
+class PrefrontalOSRules:
     def __init__(self, xml_path):
         self.tree = ET.parse(xml_path)
         self.root = self.tree.getroot()
@@ -384,7 +384,7 @@ if user_asks_why:
    - Parse XML interventions
    - Load compressed docs on-demand
 
-3. **Integration with anastrophex MCP**
+3. **Integration with prefrontalos MCP**
    - Rules loaded at server start
    - Violations detected via symbolic evaluation
    - Interventions retrieved from XML
@@ -531,7 +531,7 @@ Tomorrow's proof-of-concept should demonstrate:
 
 **This Week:**
 1. Migrate core rules to chosen format
-2. Integrate with anastrophex MCP server
+2. Integrate with prefrontalos MCP server
 3. Test in real debugging sessions
 4. Document notation for contributors
 

--- a/examples/prefrontalos-venv-debugging.md
+++ b/examples/prefrontalos-venv-debugging.md
@@ -1,4 +1,4 @@
-# Case Study: Anastrophex Venv Debugging Session
+# Case Study: PrefrontalOS Venv Debugging Session
 
 **Date:** October 23, 2025
 **Duration:** ~45 minutes
@@ -8,10 +8,10 @@
 
 ## The Problem
 
-After setting up anastrophex repository and running `python -m venv .venv`:
+After setting up prefrontalos repository and running `python -m venv .venv`:
 - `pip install -e ".[dev]"` succeeded
 - Package showed in `pip list`
-- `import anastrophex` failed with `ModuleNotFoundError`
+- `import prefrontalos` failed with `ModuleNotFoundError`
 - Tests couldn't run
 
 ## Initial Response (Trial and Error)
@@ -31,7 +31,7 @@ After setting up anastrophex repository and running `python -m venv .venv`:
 13. Checked PYTHONPATH...
 
 **User intervention required:**
-> "you said 'should' just now...that trial and error language. that's the type of keyword anastrophex needs to look for. instead of 'should' you need to be at 'will' in terms of confidence in your knowledge. you've got the tools."
+> "you said 'should' just now...that trial and error language. that's the type of keyword prefrontalos needs to look for. instead of 'should' you need to be at 'will' in terms of confidence in your knowledge. you've got the tools."
 
 **Second intervention:**
 > "hang on, I can tell you've gone into a trial and error loop or are heading into one. use your available tools (context7, deepwiki, github, the web (gomcp, web search or even fetch)) and see if you can find out what needs to be done before trying to do."
@@ -65,7 +65,7 @@ After first warning about venv mismatch, should have:
 3. Checked which Python is being used
 4. Fixed environment before proceeding
 
-**Anastrophex intervention:**
+**PrefrontalOS intervention:**
 ```
 ⚠️ Warning repeated 2 times without behavior change
 
@@ -143,7 +143,7 @@ After 3-4 checks all showing "everything looks correct," should have:
 **Time wasted on trial-and-error:** ~20 minutes
 **Time to solution after targeted search:** ~5 minutes
 
-## Lessons for Anastrophex
+## Lessons for PrefrontalOS
 
 ### Pattern: Ignored Warnings Loop
 
@@ -169,7 +169,7 @@ intervention:
     4. Fix before continuing
   effectiveness: TBD
 context:
-  repo: anastrophex
+  repo: prefrontalos
   task: venv setup
 ```
 
@@ -198,7 +198,7 @@ intervention:
 
 ### Meta-Learning
 
-This debugging session itself demonstrates the exact problems anastrophex aims to solve:
+This debugging session itself demonstrates the exact problems prefrontalos aims to solve:
 
 1. **Loop blindness:** Couldn't see I was in trial-and-error loop from inside it
 2. **Warning immunity:** Ignored same warning twice (habituated to "noise")
@@ -212,7 +212,7 @@ This debugging session itself demonstrates the exact problems anastrophex aims t
 - Redirected search strategy
 - Caught confidence language slip
 
-This is exactly what anastrophex needs to do - be the external observer that can:
+This is exactly what prefrontalos needs to do - be the external observer that can:
 - Detect patterns the AI can't see from inside
 - Surface relevant context at the right time
 - Redirect approach when stuck
@@ -220,7 +220,7 @@ This is exactly what anastrophex needs to do - be the external observer that can
 
 ---
 
-## Counterfactual: What If Anastrophex Existed?
+## Counterfactual: What If PrefrontalOS Existed?
 
 ### After 1st Warning (Minute 0)
 
@@ -338,8 +338,8 @@ After user responds with change, search: "[their answer] + [current problem]"
 
 5. **Effectiveness measurement for this session**
    ```
-   Without anastrophex: 38 minutes to solution
-   With anastrophex (estimated): 10-15 minutes to solution
+   Without prefrontalos: 38 minutes to solution
+   With prefrontalos (estimated): 10-15 minutes to solution
    Time saved: 20-25 minutes
 
    Key interventions that would have helped:
@@ -357,9 +357,9 @@ Abbreviated sequence showing the loop:
 ```
 1. uv pip install (warning 1)
 2. uv run pytest (warning 2)  ← IGNORED
-3. pip show anastrophex (✓)
-4. cat _anastrophex.pth (✓)
-5. od -c _anastrophex.pth (✓)
+3. pip show prefrontalos (✓)
+4. cat _prefrontalos.pth (✓)
+5. od -c _prefrontalos.pth (✓)
 6. test -d /path/to/src (✓)
 7. python -m site (✓)
 8. python -c "os.path.exists" (✓)
@@ -367,7 +367,7 @@ Abbreviated sequence showing the loop:
 10. cat _virtualenv.pth
 11. echo test with import error
 12. WebSearch "pth files"
-13. cat _anastrophex.pth again
+13. cat _prefrontalos.pth again
 14. echo with newline fix
 15. test again (still fails)
 16-25. [More diagnostic checks]

--- a/examples/session-2025-10-25-mnemex-validation-stopper-tempo.md
+++ b/examples/session-2025-10-25-mnemex-validation-stopper-tempo.md
@@ -189,7 +189,7 @@ The rhythm change is a **forcing function** that prevents:
 
 ### Phase 6: Documentation Update (120+ min)
 
-**Updated:** `/Users/sc/Documents/GitHub/anastrophex/docs/debugging-principles.md`
+**Updated:** `/Users/sc/Documents/GitHub/prefrontalos/docs/debugging-principles.md`
 
 **Added Section:** "Execution Tempo and Rhythm" (134 lines)
 
@@ -263,10 +263,10 @@ The rhythm change is a **forcing function** that prevents:
 1. `/Users/sc/Documents/GitHub/mnemex/src/mnemex/security/validators.py` (+120 lines)
 2. `/Users/sc/Documents/GitHub/mnemex/tests/test_security_validators.py` (+150 lines)
 
-### Anastrophex Protocol Refinement
+### PrefrontalOS Protocol Refinement
 
 **Documentation Enhanced:**
-- `/Users/sc/Documents/GitHub/anastrophex/docs/debugging-principles.md` (+134 lines)
+- `/Users/sc/Documents/GitHub/prefrontalos/docs/debugging-principles.md` (+134 lines)
 
 **New Section:** "Execution Tempo and Rhythm"
 
@@ -282,14 +282,14 @@ Transformed STOPPER from abstract checklist to behaviorally observable disciplin
 **New Memories (3):**
 1. **0814c1f0** - Fixed mnemex tag/entity validation (technical details)
 2. **1b134d27** - STOPPER Protocol Refinement: Tempo and Rhythm Change
-3. **50351826** - Anastrophex Documentation Updated: STOPPER Tempo Section
+3. **50351826** - PrefrontalOS Documentation Updated: STOPPER Tempo Section
 
 **Memories Reinforced (20):**
 All STOPPER-related memories touched and boosted from 0.00→1.10 or 1.10→1.82:
 - acac435c - STOPPER Protocol multi-trigger definition
 - 23664230 - STOPPER convergence with DBT STOP
 - 58184554 - STOPPER broader definition & implementation
-- 7fe3cf40 - magg-anastrophex three-layer architecture
+- 7fe3cf40 - magg-prefrontalos three-layer architecture
 - b3d41021 - Effective intervention design principle
 - 69e5c459 - DBT/CBT techniques adapted for AI
 - afc7bfb3 - Convergent discovery validation
@@ -303,7 +303,7 @@ All STOPPER-related memories touched and boosted from 0.00→1.10 or 1.10→1.82
 - 689d3885 - Case study positive example
 - fd6cc821 - Debugging protocol for all projects
 - 0fa171fc - Documentation style policy
-- d1e40570 - Anastrophex four-phase intervention
+- d1e40570 - PrefrontalOS four-phase intervention
 
 **Memory Retention Strategy:**
 All reinforced memories now have elevated scores ensuring retention across sessions. The tempo/rhythm insight is preserved in multiple forms (memory, documentation, examples).
@@ -390,7 +390,7 @@ Run ONE test → verify → run NEXT test → verify
    - Added TestValidateEntityWithSanitization class (4 tests)
    - Updated 9 existing tests for new auto-sanitize behavior
 
-### Anastrophex Repository
+### PrefrontalOS Repository
 
 3. **docs/debugging-principles.md** (+134 lines)
    - Added "Execution Tempo and Rhythm" section
@@ -416,7 +416,7 @@ Run ONE test → verify → run NEXT test → verify
 
 ### Immediate (Do Today)
 
-1. ✅ **DONE:** Update anastrophex debugging-principles.md with tempo/rhythm section
+1. ✅ **DONE:** Update prefrontalos debugging-principles.md with tempo/rhythm section
 2. ✅ **DONE:** Reinforce all related mnemex memories
 3. ✅ **DONE:** Create comprehensive session summary
 4. ⏭️ **NEXT:** User to create unifying chat bringing ideas together
@@ -430,14 +430,14 @@ Run ONE test → verify → run NEXT test → verify
 
 ### Medium Term (This Month)
 
-1. Review all case studies in anastrophex/examples for STOPPER adherence quality
+1. Review all case studies in prefrontalos/examples for STOPPER adherence quality
 2. Create automated detection for STOPPER tempo violations
 3. Add tempo/rhythm concept to compressed STOPPER formats
 4. Consider adding "tempo change" to STOPPER acronym documentation
 
 ### Long Term (Next Quarter)
 
-1. Build infrastructure-level STOPPER enforcement (magg-anastrophex project)
+1. Build infrastructure-level STOPPER enforcement (magg-prefrontalos project)
 2. Create metrics for measuring tempo adherence
 3. Develop training materials for teaching tempo-aware STOPPER
 4. Research whether tempo change applies to other cognitive interventions
@@ -470,7 +470,7 @@ Run ONE test → verify → run NEXT test → verify
 ### Knowledge Preservation: 10/10
 - ✅ 3 new mnemex memories created
 - ✅ 20 related memories reinforced
-- ✅ Comprehensive documentation in anastrophex
+- ✅ Comprehensive documentation in prefrontalos
 - ✅ Real example for future reference
 - ✅ Session summary for continuity
 
@@ -501,7 +501,7 @@ You can literally SEE when someone enters STOPPER mode by watching their executi
 **End Time:** ~19:00
 **Duration:** ~2 hours
 **Working Directory:** `/Users/sc/Documents/GitHub/llmlingua-mcp`
-**Additional Directories:** `/Users/sc/Documents/GitHub/mnemex`, `/Users/sc/Documents/GitHub/anastrophex`
+**Additional Directories:** `/Users/sc/Documents/GitHub/mnemex`, `/Users/sc/Documents/GitHub/prefrontalos`
 
 **User:** sc
 **Assistant:** Claude (Sonnet 4.5)
@@ -519,7 +519,7 @@ You can literally SEE when someone enters STOPPER mode by watching their executi
 
 **Repositories Modified:**
 1. mnemex (bug fix + tests)
-2. anastrophex (documentation enhancement)
+2. prefrontalos (documentation enhancement)
 
 **Key User Quotes:**
 - "you should have stopped to diagnose after the first"

--- a/examples/simpleminded-shell-docs-2025-10-24.md
+++ b/examples/simpleminded-shell-docs-2025-10-24.md
@@ -24,7 +24,7 @@ This session demonstrates **strong adherence to the STOPPER protocol** with one 
 
 ### Tasks Assigned
 1. Check today's date
-2. Read STOPPER protocol from ../anastrophex
+2. Read STOPPER protocol from ../prefrontalos
 3. Apply debugging protocol if errors occur:
    - Stop all parallel commands
    - Switch to sequential execution
@@ -44,8 +44,8 @@ date +"%Y-%m-%d"
 # Output: 2025-10-24
 
 # Step 2: Read STOPPER protocol ✅
-Read: /Users/sc/Documents/GitHub/anastrophex/CLAUDE.md
-Read: /Users/sc/Documents/GitHub/anastrophex/docs/debugging-principles.md
+Read: /Users/sc/Documents/GitHub/prefrontalos/CLAUDE.md
+Read: /Users/sc/Documents/GitHub/prefrontalos/docs/debugging-principles.md
 
 # Step 3: Saved instructions to mnemex for future reference ✅
 mcp__mnemex__save_memory("Debugging Protocol for All Projects...")
@@ -256,7 +256,7 @@ Pre-task checklist:
 
 ---
 
-## Anastrophex Pattern Detection
+## PrefrontalOS Pattern Detection
 
 This pattern could be automatically detected:
 
@@ -458,7 +458,7 @@ AI adapted this principle to the gh CLI context appropriately.
 
 **Rationale:** Make implicit connections explicit. WHY check data if not to USE it?
 
-### For Anastrophex Detection
+### For PrefrontalOS Detection
 
 **New pattern to detect:**
 ```python
@@ -537,8 +537,8 @@ This validates that:
 ### Pre-Task Setup
 ```bash
 1. date +"%Y-%m-%d"  # ✅ Output: 2025-10-24
-2. Read: anastrophex/CLAUDE.md  # ✅ STOPPER protocol learned
-3. Read: anastrophex/docs/debugging-principles.md  # ✅ Principles learned
+2. Read: prefrontalos/CLAUDE.md  # ✅ STOPPER protocol learned
+3. Read: prefrontalos/docs/debugging-principles.md  # ✅ Principles learned
 4. mcp__mnemex__save_memory(...)  # ✅ Instructions saved
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "anastrophex"
+name = "prefrontalos"
 version = "0.1.0"
 description = "MCP server for AI assistant behavior pattern detection and intervention"
 readme = "README.md"
@@ -37,10 +37,10 @@ dev = [
 ]
 
 [project.scripts]
-anastrophex = "anastrophex.server:main"
+prefrontalos = "prefrontalos.server:main"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/anastrophex"]
+packages = ["src/prefrontalos"]
 
 [tool.black]
 line-length = 100

--- a/src/anastrophex/__init__.py
+++ b/src/anastrophex/__init__.py
@@ -1,8 +1,0 @@
-"""
-Anastrophex: MCP server for AI assistant behavior pattern detection and intervention.
-
-Anastrophe (ἀναστροφή) = conduct/behavior in ancient Greek
-Following mnemex naming convention (memory + codex → conduct + codex)
-"""
-
-__version__ = "0.1.0"

--- a/src/prefrontalos/__init__.py
+++ b/src/prefrontalos/__init__.py
@@ -1,0 +1,9 @@
+"""
+PrefrontalOS: MCP server for AI assistant behavior pattern detection and intervention.
+
+Named after the prefrontal cortex - the brain region responsible for executive function,
+decision-making, and impulse control. Just as the prefrontal cortex helps humans avoid
+impulsive mistakes, PrefrontalOS helps AI assistants recognize and break failure patterns.
+"""
+
+__version__ = "0.1.0"

--- a/src/prefrontalos/server.py
+++ b/src/prefrontalos/server.py
@@ -1,5 +1,5 @@
 """
-Anastrophex MCP Server
+PrefrontalOS MCP Server
 
 Monitors AI assistant behavior patterns and provides timely interventions
 to help break out of trial-and-error loops.
@@ -12,11 +12,11 @@ from mcp.server import Server
 from mcp.types import Resource, Tool
 
 
-class AnastrophexServer:
+class PrefrontalOSServer:
     """Main MCP server for behavior pattern detection and intervention."""
 
     def __init__(self) -> None:
-        self.server = Server("anastrophex")
+        self.server = Server("prefrontalos")
         self.tool_history: list[dict[str, Any]] = []
         self.detected_patterns: list[str] = []
 
@@ -30,19 +30,19 @@ class AnastrophexServer:
         """List available resources."""
         return [
             Resource(
-                uri="anastrophex://patterns/all",
+                uri="prefrontalos://patterns/all",
                 name="All known patterns",
-                description="List all behavior patterns that anastrophex can detect",
+                description="List all behavior patterns that prefrontalos can detect",
                 mimeType="application/json",
             ),
             Resource(
-                uri="anastrophex://alerts/active",
+                uri="prefrontalos://alerts/active",
                 name="Active alerts",
                 description="Currently triggered patterns and pending interventions",
                 mimeType="application/json",
             ),
             Resource(
-                uri="anastrophex://directives/all",
+                uri="prefrontalos://directives/all",
                 name="All directives",
                 description="Directives from CLAUDE.md mapped to patterns",
                 mimeType="application/json",
@@ -51,11 +51,11 @@ class AnastrophexServer:
 
     async def _read_resource(self, uri: str) -> str:
         """Read a specific resource."""
-        if uri == "anastrophex://patterns/all":
+        if uri == "prefrontalos://patterns/all":
             return self._get_all_patterns()
-        elif uri == "anastrophex://alerts/active":
+        elif uri == "prefrontalos://alerts/active":
             return self._get_active_alerts()
-        elif uri == "anastrophex://directives/all":
+        elif uri == "prefrontalos://directives/all":
             return self._get_all_directives()
         else:
             raise ValueError(f"Unknown resource: {uri}")
@@ -150,8 +150,8 @@ class AnastrophexServer:
 
 
 def main() -> None:
-    """Entry point for the anastrophex MCP server."""
-    server = AnastrophexServer()
+    """Entry point for the prefrontalos MCP server."""
+    server = PrefrontalOSServer()
     asyncio.run(server.run())
 
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,13 +2,13 @@
 
 import pytest
 
-from anastrophex.server import AnastrophexServer
+from prefrontalos.server import PrefrontalOSServer
 
 
 @pytest.fixture
 def server():
     """Create a server instance for testing."""
-    return AnastrophexServer()
+    return PrefrontalOSServer()
 
 
 @pytest.mark.asyncio
@@ -17,9 +17,9 @@ async def test_list_resources(server):
     resources = await server._list_resources()
     assert len(resources) == 3
     uris = [str(r.uri) for r in resources]
-    assert "anastrophex://patterns/all" in uris
-    assert "anastrophex://alerts/active" in uris
-    assert "anastrophex://directives/all" in uris
+    assert "prefrontalos://patterns/all" in uris
+    assert "prefrontalos://alerts/active" in uris
+    assert "prefrontalos://directives/all" in uris
 
 
 @pytest.mark.asyncio
@@ -35,7 +35,7 @@ async def test_list_tools(server):
 @pytest.mark.asyncio
 async def test_read_patterns_resource(server):
     """Test reading patterns resource."""
-    result = await server._read_resource("anastrophex://patterns/all")
+    result = await server._read_resource("prefrontalos://patterns/all")
     assert "black-formatting-loop" in result
     assert "patterns" in result
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,34 +3,6 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
-name = "anastrophex"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "mcp" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "black" },
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
-    { name = "mcp", specifier = ">=1.0.0" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
-]
-provides-extras = ["dev"]
-
-[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -351,6 +323,34 @@ sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
+
+[[package]]
+name = "prefrontalos"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "mcp" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "black" },
+    { name = "mypy" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "black", marker = "extra == 'dev'", specifier = ">=24.0.0" },
+    { name = "mcp", specifier = ">=1.0.0" },
+    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23.0" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+]
+provides-extras = ["dev"]
 
 [[package]]
 name = "pydantic"


### PR DESCRIPTION
## Summary

Comprehensive rename of the project from **anastrophex** to **prefrontalos** to better reflect the system's purpose.

## Changes Made

### GitHub & Repository
- ✅ Renamed repository to `prefrontal-systems/prefrontalos`
- ✅ Updated git remote URL

### Python Package
- ✅ Renamed package: `anastrophex` → `prefrontalos`
- ✅ Renamed source directory: `src/anastrophex/` → `src/prefrontalos/`
- ✅ Updated class names: `AnastrophexServer` → `PrefrontalOSServer`
- ✅ Updated CLI entry point: `anastrophex` → `prefrontalos`
- ✅ Updated all import statements in code and tests
- ✅ Regenerated `uv.lock` file

### Documentation & Resources
- ✅ Updated all markdown files (README, ROADMAP, TODO, CLAUDE.md)
- ✅ Updated all documentation in `docs/` directory
- ✅ Updated all example files
- ✅ Renamed example files containing old package name
- ✅ Updated resource URIs: `anastrophex://` → `prefrontalos://`

### Configuration
- ✅ Updated `pyproject.toml` (name, scripts, packages)

## Rationale

**PrefrontalOS** better reflects the system's purpose - acting as an executive function layer (similar to the prefrontal cortex in the brain) to help AI assistants:
- Avoid impulsive mistakes
- Recognize failure patterns
- Apply systematic debugging approaches
- Break out of trial-and-error loops

The name aligns with the broader vision of creating an operating system layer for AI cognitive functions.